### PR TITLE
 Added word highlighting:

### DIFF
--- a/app/src/main/java/com/zularizal/homedashboard/MainActivity.java
+++ b/app/src/main/java/com/zularizal/homedashboard/MainActivity.java
@@ -68,6 +68,10 @@ public class MainActivity extends AppCompatActivity {
 
         Quote[] matches = null;
 
+        // remove any highlighting.
+        for (Quote q: mQuotes)
+            q.clearHits();
+
         if (rbExact.isChecked())
             matches = Matches(s);
         else if (rbAll.isChecked())
@@ -89,7 +93,7 @@ public class MainActivity extends AppCompatActivity {
             TextView tvSpeaker = (TextView) tr.findViewById(R.id.txtSpeaker);
             TextView tvQuotation = (TextView) tr.findViewById(R.id.txtQuotation);
             tvSpeaker.setText(q.Speaker);
-            tvQuotation.setText(q.Quotation);
+            tvQuotation.setText(q.highlightedText());
             tl.addView(tr, new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT));
             final Quote quoteToView = q;
 
@@ -114,7 +118,10 @@ public class MainActivity extends AppCompatActivity {
         for (Quote q : mQuotes) {
             if (q == null)
                 continue;
-            if (bm.findAll(q.Quotation).size() > 0) {
+            List<Integer> result =  bm.findAll(q.Quotation);
+            if (result.size() > 0) {
+                for (int i : result)
+                    q.addHit(new WordRange(i, i + s.length()));
                 resultmatches.add(q);
             }
         }
@@ -140,8 +147,14 @@ public class MainActivity extends AppCompatActivity {
 
             Boolean fIsMatch = true;
             for (TBM bm : matchers) {
-                if (bm.findAll(q.Quotation).size() == 0)
+                List<Integer> result =  bm.findAll(q.Quotation);
+                if (result.size() == 0)
                     fIsMatch = false;
+                else {
+                    for (int i : result) {
+                        q.addHit(new WordRange(i, i + bm.matchLength));
+                    }
+                }
             }
 
             if (fIsMatch)
@@ -178,6 +191,9 @@ public class MainActivity extends AppCompatActivity {
                 }
 
                 int matchPos = lst.get(0);
+
+                int adjustedMatchPos = matchPos + (q.Quotation.length() - searchString.length());
+                q.addHit(new WordRange(adjustedMatchPos, adjustedMatchPos + matchers[i].matchLength));
 
                 searchString = searchString.substring(matchPos + words[i].length());
             }

--- a/app/src/main/java/com/zularizal/homedashboard/Quote.java
+++ b/app/src/main/java/com/zularizal/homedashboard/Quote.java
@@ -1,17 +1,30 @@
 package com.zularizal.homedashboard;
 
+import android.content.res.ColorStateList;
+import android.graphics.Color;
+import android.graphics.Typeface;
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.text.Spannable;
+import android.text.SpannableString;
+import android.text.style.BackgroundColorSpan;
+import android.text.style.TextAppearanceSpan;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 
 public class Quote implements Parcelable {
+
 
     private int ID;
     public String Speaker;
     public String Quotation;
     public String Place;
     public Date Timestamp;
+    private ArrayList<WordRange> hits;
+    int HitForeColor = Color.RED;
+    int HitBackColor = Color.YELLOW;
 
     Quote(int id, String speaker, String quotation, String place, Date timestamp) {
         ID = id;
@@ -19,6 +32,7 @@ public class Quote implements Parcelable {
         Quotation = quotation;
         Place = place;
         Timestamp = timestamp;
+        hits = new ArrayList<>();
     }
 
     private Quote(Parcel in) {
@@ -27,6 +41,11 @@ public class Quote implements Parcelable {
         Quotation = in.readString();
         Place = in.readString();
         Timestamp = (Date) in.readSerializable();
+        int wordrangeCount = in.readInt();
+        WordRange[] words = new WordRange[wordrangeCount];
+        in.readTypedArray(words, WordRange.CREATOR);
+        hits = new ArrayList<>();
+        hits.addAll(Arrays.asList(words));
     }
 
     @Override
@@ -36,6 +55,8 @@ public class Quote implements Parcelable {
         parcel.writeString(Quotation);
         parcel.writeString(Place);
         parcel.writeSerializable(Timestamp);
+        parcel.writeInt(hits.size());
+        parcel.writeTypedArray(hits.toArray(new WordRange[0]), i);
     }
 
     @Override
@@ -53,4 +74,30 @@ public class Quote implements Parcelable {
             return new Quote[size];
         }
     };
+
+    public void clearHits() {
+        hits = new ArrayList<>();
+    }
+
+    public void addHit(WordRange wr) {
+        hits.add(wr);
+    }
+
+    public Spannable highlightedText() {
+        if (Quotation == null)
+            return new SpannableString("");
+
+        Spannable s = new SpannableString(Quotation);
+
+        for (WordRange wr : hits) {
+            ColorStateList foreColor = new ColorStateList(new int[][] { new int[] {}}, new int[] {HitForeColor});
+            TextAppearanceSpan textAppearanceSpan = new TextAppearanceSpan(null, Typeface.BOLD, -1, foreColor, null);
+            BackgroundColorSpan backgroundColorSpan = new BackgroundColorSpan(HitBackColor);
+
+            s.setSpan(textAppearanceSpan, wr.start, wr.end, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+            s.setSpan(backgroundColorSpan, wr.start, wr.end, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+        }
+
+        return s;
+    }
 }

--- a/app/src/main/java/com/zularizal/homedashboard/QuoteDetailActivity.java
+++ b/app/src/main/java/com/zularizal/homedashboard/QuoteDetailActivity.java
@@ -33,7 +33,7 @@ public class QuoteDetailActivity extends AppCompatActivity {
             ((TextView) findViewById(R.id.lblSpeaker)).setText(q.Speaker);
             ((TextView) findViewById(R.id.lblPlace)).setText(q.Place);
             ((TextView) findViewById(R.id.lblDate)).setText(q.Timestamp.toString());
-            ((TextView) findViewById(R.id.lblQuote)).setText(q.Quotation);
+            ((TextView) findViewById(R.id.lblQuote)).setText(q.highlightedText());
         }
     }
 

--- a/app/src/main/java/com/zularizal/homedashboard/TBM.java
+++ b/app/src/main/java/com/zularizal/homedashboard/TBM.java
@@ -8,6 +8,7 @@ public class TBM {
     private int m;
     private int[] bmGs, bmBc;
     private char[] x;
+    public int matchLength;
 
     private static void preBmBc(char[] x, int bmBc[]) {
         int i, m = x.length;
@@ -116,6 +117,7 @@ public class TBM {
         tbm.bmBc = bmBc;
         tbm.bmGs = bmGs;
         tbm.x = x;
+        tbm.matchLength = pattern.length();
 
         return tbm;
     }

--- a/app/src/main/java/com/zularizal/homedashboard/WordRange.java
+++ b/app/src/main/java/com/zularizal/homedashboard/WordRange.java
@@ -1,0 +1,45 @@
+package com.zularizal.homedashboard;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+public class WordRange implements Parcelable {
+    public int start;
+    public int end;
+
+    public WordRange() {
+        start = end = 0;
+    }
+
+    WordRange(int startpos, int endpos) {
+        start = startpos;
+        end = endpos;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    private WordRange(Parcel in) {
+        start = in.readInt();
+        end = in.readInt();
+    }
+
+    @Override
+    public void writeToParcel(Parcel parcel, int i) {
+        parcel.writeInt(start);
+        parcel.writeInt(end);
+    }
+
+    public static final WordRange.Creator<WordRange> CREATOR
+            = new Parcelable.Creator<WordRange>() {
+        public WordRange createFromParcel(Parcel in) {
+            return new WordRange(in);
+        }
+
+        public WordRange[] newArray(int size) {
+            return new WordRange[size];
+        }
+    };
+}


### PR DESCRIPTION
     - New WordRange object encapsulates a start-end pair of positions to highlight
     - Quote how has three new methods around highlighting hits:
       - clearHits removes all hits (important before doing a search)
       - addHit adds a wordrange for a hit
       - highlightedText returns a spannable with the hits highlighted
     - Quote parcels the hits so that it can be preserved through view details.
     - Quote has two Color integers: a foreground color and a background color, that can be set.  Default to red/yellow (respectively)
     - TBM exposes a wordlength object, so that we can correctly set hit wordranges when we find a hit.